### PR TITLE
Forgot to add subdomain support

### DIFF
--- a/css/nyaa.si.user.css
+++ b/css/nyaa.si.user.css
@@ -16,7 +16,7 @@
     "Firefox":"firefox",
 }
 ==/UserStyle== */
-@-moz-document domain("nyaa.si"), domain("nyaa.lol") {
+@-moz-document regexp("https?:\\/\\/(.+\\.)?nyaa\\.(si|lol)\\/.*") {
 body {
     background-color: #1C1C1C;
     color: #CCCCCC;


### PR DESCRIPTION
I didn't receive a response in #1 , so I'll just make a PR
>@sabakuran I just realized I forgot to enable subdomain support on that regex, it didn't cross my mind because I don't use the subdomain, due to it not being apart of the mirror I use, I did fix it however. Would you like me to submit another PR?

Having it as regex would make it easier to add any more mirrors if needed, cause you can add a pipe on the tld or sld, without having to add an entirely new domain.