### PR TITLE
nyaa.iss.one now redirects to nyaa.iss.ink

### DIFF
--- a/css/nyaa.si.user.css
+++ b/css/nyaa.si.user.css
@@ -16,7 +16,7 @@
     "Firefox":"firefox",
 }
 ==/UserStyle== */
-@-moz-document regexp("https?:\\/\\/(.+\\.)?(nyaa|fap(?!\\.lol))\\.(si|lol|iss\\.one)\\/.*") {
+@-moz-document regexp("https?:\\/\\/(.+\\.)?(nyaa|fap(?!\\.lol))\\.(si|lol|iss\\.(one|ink))\\/.*") {
 body {
     background-color: #1C1C1C;
     color: #CCCCCC;


### PR DESCRIPTION
I would remove `one`, however, the `one` TLD is still being used by fap.iss.one